### PR TITLE
Fix non-touched old archives packing.

### DIFF
--- a/Archivate.sh
+++ b/Archivate.sh
@@ -9,7 +9,7 @@ while read -r line; do
 	start_date="$line 00:00:00";
 	end_date="$line 23:59:59";
 	archive_title=`date --date $line +"%d-%m-%Y"`;
-	find ./downloaded -type f -newermt "$start_date" -not -newermt "$end_date" -printf "%f\0" | tar -czf ./downloaded/$archive_title.tgz -C ./downloaded --null -T -;
+	find ./downloaded -type f \( -iname '*.jpg' -o -iname '*.mp4' \) -newermt "$start_date" -not -newermt "$end_date" -printf "%f\0" | tar -czf ./downloaded/$archive_title.tgz -C ./downloaded --null -T -;
 	if tar -tzf ./downloaded/$archive_title.tgz >/dev/null;then
 		find ./downloaded -type f -newermt "$start_date" -not -newermt "$end_date" -exec rm {} +;
 	fi;


### PR DESCRIPTION
Pack only allowed extensions.

For example, if you don't move archive, then the next day it will also be packed into one common, coz creation date was same.
![изображение](https://user-images.githubusercontent.com/9306996/77288613-1e906b80-6cd0-11ea-8309-ab613bb7cdc3.png)

This is inessential bug, btw why not to fix it.